### PR TITLE
make it appear only as splashscreen

### DIFF
--- a/KDE-Story-Blue SplashScreen/KDE-Story-Blue-Splash-6/metadata.json
+++ b/KDE-Story-Blue SplashScreen/KDE-Story-Blue-Splash-6/metadata.json
@@ -1,5 +1,5 @@
 {
-    "KPackageStructure": "Plasma/LookAndFeel",
+    "KPackageStructure": "Plasma/LookAndFeel/Splash",
     "KPlugin": {
         "Authors": [
             {


### PR DESCRIPTION
Created my own splashscreen earlier and noticed some of the existing ones (for plasma6) appear both in splashscreens but also in the Global Theme main category